### PR TITLE
feat(theme): add theme switching to quest page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,15 +5,26 @@ import Navbar from "./components/layout/Navbar";
 import Footer from "./components/layout/Footer";
 import Quest from "./pages/Quest";
 import Achievements from "./pages/Achievements";
+import { useState, useEffect } from "react";
 
 export default function App() {
+  const [theme, setTheme] = useState(
+    localStorage.getItem("theme") ? localStorage.getItem("theme") : "light",
+  );
+
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+    const localTheme = localStorage.getItem("theme");
+    document.querySelector("html").setAttribute("data-theme", localTheme);
+  }, [theme]);
+
   return (
     <Router>
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/npc" element={<NpcDetail />} />
-        <Route path="/quest" element={<Quest />} />
+        <Route path="/quest" element={<Quest setTheme={setTheme} />} />
         <Route path="/achievements" element={<Achievements />} />
       </Routes>
       <Footer />

--- a/src/components/achievements/AchievementsCard.jsx
+++ b/src/components/achievements/AchievementsCard.jsx
@@ -1,7 +1,7 @@
 export default function AchievementsCard({ children }) {
   return (
-    <div className="card bg-white shadow-lg">
-      <div className="card-body">{children}</div>
+    <div className="card bg-neutral shadow-lg">
+      <div className="card-body text-neutral-content">{children}</div>
     </div>
   );
 }

--- a/src/components/achievements/CompletedMissionItem.jsx
+++ b/src/components/achievements/CompletedMissionItem.jsx
@@ -1,5 +1,3 @@
-import { CheckCircle2 } from "lucide-react";
-
 export default function CompletedMissionItem({ mission }) {
   return (
     <>
@@ -11,7 +9,6 @@ export default function CompletedMissionItem({ mission }) {
             className="mb-4 flex items-center justify-between last:mb-0"
           >
             <div className="flex items-center">
-              <CheckCircle2 className="mr-2 h-5 w-5 text-green-500" />
               <span>{mission.title}</span>
             </div>
             <div className="flex items-center">
@@ -20,7 +17,7 @@ export default function CompletedMissionItem({ mission }) {
               >
                 {mission.difficulty}
               </span>
-              <span className="ml-2 font-bold">{mission.points} pts</span>
+              <span className="ml-2 font-bold">{mission.points} p</span>
             </div>
           </div>
         ))}

--- a/src/components/achievements/TotalPoints.jsx
+++ b/src/components/achievements/TotalPoints.jsx
@@ -11,9 +11,11 @@ export default function TotalPoints({ totalPoints }) {
 
   return (
     <>
-      <h2 className="card-title text-center">Total Poin & Peringkat</h2>
-      <p className="text-center text-4xl font-bold">{totalPoints} pts</p>
-      <p className="text-center text-2xl font-semibold text-gray-700">
+      <h2 className="card-title text-center item-center">
+        Total Poin & Peringkat
+      </h2>
+      <p className="text-center text-4xl font-bold">{totalPoints} p</p>
+      <p className="text-center text-2xl font-semibold ">
         Peringkat: {getRank(totalPoints)}
       </p>
     </>

--- a/src/components/home/FeatureCard.jsx
+++ b/src/components/home/FeatureCard.jsx
@@ -1,12 +1,12 @@
 export default function FeatureCard({ icon: Icon, title, description }) {
   return (
-    <div className="card bg-neutral-content shadow-lg">
+    <div className="card bg-neutral shadow-lg">
       <div className="card-body text-center">
-        <h3 className="card-title flex items-center justify-center">
+        <h3 className="card-title flex items-center text-neutral-content justify-center">
           <Icon className="mr-2 h-6 w-6" />
           {title}
         </h3>
-        <p>{description}</p>
+        <p className="text-neutral-content">{description}</p>
       </div>
     </div>
   );

--- a/src/components/home/NpcSection.jsx
+++ b/src/components/home/NpcSection.jsx
@@ -3,22 +3,28 @@ import { Leaf, Zap } from "lucide-react";
 export default function NPCSection() {
   return (
     <section className="mb-12 grid gap-8 md:grid-cols-2">
-      <div className="card bg-neutral-content shadow-lg">
+      <div className="card bg-neutral shadow-lg">
         <div className="card-body">
-          <h2 className="card-title flex items-center">
-            <Leaf className="mr-2 h-6 w-6 text-green-600" /> Greenia
+          <h2 className="card-title flex items-center text-neutral-content">
+            <Leaf className="mr-2 h-6 w-6 " /> Greenia
           </h2>
-          <p className="text-sm text-gray-500">Penjaga alam dari masa lalu</p>
-          <p>Pelajari kebijaksanaan alam untuk melestarikan lingkungan.</p>
+          <p className="text-sm text-neutral-content">
+            Penjaga alam dari masa lalu
+          </p>
+          <p className="text-neutral-content">
+            Pelajari kebijaksanaan alam untuk melestarikan lingkungan.
+          </p>
         </div>
       </div>
-      <div className="card bg-neutral-content shadow-lg">
+      <div className="card bg-neutral shadow-lg">
         <div className="card-body">
-          <h2 className="card-title flex items-center">
-            <Zap className="mr-2 h-6 w-6 text-blue-600" /> Okta
+          <h2 className="card-title flex items-center text-neutral-content">
+            <Zap className="mr-2 h-6 w-6" /> Okta
           </h2>
-          <p className="text-sm text-gray-500">Utusan dari masa depan</p>
-          <p>Jelajahi inovasi hijau untuk masa kini.</p>
+          <p className="text-sm text-neutral-content">Utusan dari masa depan</p>
+          <p className="text-neutral-content">
+            Jelajahi inovasi hijau untuk masa kini.
+          </p>
         </div>
       </div>
     </section>

--- a/src/components/home/WelcomeSection.jsx
+++ b/src/components/home/WelcomeSection.jsx
@@ -3,11 +3,9 @@ import { Link } from "react-router-dom";
 
 export default function WelcomeSection() {
   return (
-    <section className="mb-12 text-center">
-      <h1 className="mb-4 text-4xl font-bold text-primary-content">
-        Selamat Datang di TerraQuest
-      </h1>
-      <p className="mb-8 text-xl text-gray-600">
+    <section className="mb-12 text-center text-current">
+      <h1 className="mb-4 text-4xl font-bold">Selamat Datang di TerraQuest</h1>
+      <p className="mb-8 text-xl">
         Bergabunglah dalam petualangan untuk menyelamatkan bumi melalui
         quest-quest interaktif!
       </p>

--- a/src/components/npc/NpcContent.jsx
+++ b/src/components/npc/NpcContent.jsx
@@ -14,7 +14,7 @@ export default function NpcContent() {
   }
 
   return (
-    <div role="tablist" className="tabs tabs-lifted">
+    <div role="tablist" className="tabs tabs-bordered border-neutral-300">
       {npcData.map((npc, index) => (
         <>
           {/* Input radio untuk setiap tab dengan label unik */}
@@ -22,7 +22,7 @@ export default function NpcContent() {
             type="radio"
             name="npc_tabs_2"
             role="tab"
-            className="tab"
+            className="tab mx-2"
             aria-label={npc.name}
             id={`tab${index + 1}`}
             defaultChecked={
@@ -33,7 +33,7 @@ export default function NpcContent() {
 
           <div
             role="tabpanel"
-            className="tab-content bg-base-100 border-base-300 rounded-box p-6"
+            className="tab-content rounded-box p-6"
             id={`tabpanel${index + 1}`}
           >
             <NpcInfo selectedNpc={npc} />

--- a/src/components/npc/NpcInfo.jsx
+++ b/src/components/npc/NpcInfo.jsx
@@ -2,8 +2,8 @@ import ListItem from "./ListItem";
 
 export default function NpcInfo({ selectedNpc }) {
   return (
-    <div className="card mb-8 w-full bg-neutral-content shadow-md">
-      <div className="card-body">
+    <div className="card mb-8 w-full bg-neutral shadow-md">
+      <div className="card-body text-neutral-content">
         <h2 className="card-title">{selectedNpc.name}</h2>
         <p className="text-sm text-gray-500">{selectedNpc.title}</p>
         <p className="mt-4">{selectedNpc.description}</p>

--- a/src/components/npc/QuestItem.jsx
+++ b/src/components/npc/QuestItem.jsx
@@ -4,14 +4,14 @@ export default function QuestItem({ quest }) {
   return (
     <div
       tabIndex={0}
-      className="collapse collapse-arrow rounded-box border border-base-300 bg-neutral-content mb-4"
+      className="collapse collapse-arrow rounded-box border border-base-300 bg-neutral mb-4"
     >
       <input type="checkbox" className="peer" />
-      <div className="collapse-title flex items-center justify-between text-lg font-medium">
+      <div className="collapse-title flex items-center justify-between text-lg font-medium text-neutral-content">
         <span>{quest.title}</span>
         <QuestBadge difficulty={quest.difficulty} />
       </div>
-      <div className="collapse-content">
+      <div className="collapse-content text-neutral-content">
         <p>{quest.description}</p>
       </div>
     </div>

--- a/src/components/quest/QuestContent.jsx
+++ b/src/components/quest/QuestContent.jsx
@@ -4,7 +4,7 @@ import { useNpcData } from "../../hooks/useNpcData";
 import { generateQuest } from "../../services/geminiApiServices";
 import SelectNpc from "./SelectNpc";
 
-export default function QuestContent() {
+export default function QuestContent({ setTheme }) {
   const { npcData, selectedNpc, handleNpcChange } = useNpcData();
   const [quests, setQuests] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -57,6 +57,7 @@ export default function QuestContent() {
         handleNpcChange={handleNpcChange}
         handleSearchQuests={generateQuestHandler}
         loading={loading}
+        setTheme={setTheme}
       />
       {error && <p className="mt-4 text-red-500">{error}</p>}
       {quests.length > 0 && (

--- a/src/components/quest/SelectNpc.jsx
+++ b/src/components/quest/SelectNpc.jsx
@@ -7,8 +7,15 @@ export default function SelectNpc({
   handleNpcChange,
   handleSearchQuests,
   loading,
+  setTheme,
 }) {
   const [selectedNPC, setSelectedNPC] = useState(selectedNpc);
+
+  useEffect(() => {
+    const npcTheme = npcData.find((npc) => npc.name === selectedNPC)?.theme;
+    if (!npcTheme) return;
+    setTheme(npcTheme);
+  }, [npcData, selectedNPC, setTheme]);
 
   useEffect(() => {
     setSelectedNPC(selectedNpc);

--- a/src/pages/Quest.jsx
+++ b/src/pages/Quest.jsx
@@ -1,9 +1,9 @@
 import QuestContent from "../components/quest/QuestContent";
 
-export default function Quest() {
+export default function Quest({ setTheme }) {
   return (
     <div className="container mx-auto min-h-screen p-4">
-      <QuestContent />
+      <QuestContent setTheme={setTheme} />
     </div>
   );
 }


### PR DESCRIPTION
Adds theme switching functionality to the quest page, allowing users to change the appearance of the page based on the NPC they select.

The selected NPC's theme is set as the current theme for the quest page, providing a more immersive and cohesive experience for users. This enhancement allows users to personalize their quest experience and better engage with the content.